### PR TITLE
When using the wavefront GUI, tag lookups are evaluated with

### DIFF
--- a/wavectl/BaseWavefrontCommand.py
+++ b/wavectl/BaseWavefrontCommand.py
@@ -210,9 +210,8 @@ class BaseWavefrontCommand(BaseCommand):
 
         for ct in customerTag:
             e = {
-                "key": "tags.customerTags",
-                "value": ct,
-                "matchingMethod": "EXACT"
+                "key": "tagpath",
+                "value": ct
             }
             ql.append(e)
 


### PR DESCRIPTION
the "tagpath" behavior instead of the "tag" behavior by default.
tagpath allows lookups for "kingdom" to match both "kingdom"
as well as "kingdom.phylum.class", whereas using tag only allows
exact match lookups.

Since wavefront customerTag objects are designed to be hierarchical
the default behavior should be to do tagpath lookups both to make
full tag lookup functionality available as well as to preserve
the default behavior of tag lookups in the wavefront web GUI.

Closes #29